### PR TITLE
Retry failed vacancy analyses

### DIFF
--- a/database.py
+++ b/database.py
@@ -46,6 +46,8 @@ class Vacancy:
     applied_at: str | None
     approver_id: int | None
     error_text: str
+    analysis_retry_count: int
+    analysis_next_retry_at: str | None
 
 
 @dataclass(frozen=True)
@@ -145,7 +147,9 @@ class Database:
                     applied_at TEXT,
                     approver_id INTEGER,
                     permit_hash TEXT,
-                    error_text TEXT NOT NULL DEFAULT ''
+                    error_text TEXT NOT NULL DEFAULT '',
+                    analysis_retry_count INTEGER NOT NULL DEFAULT 0,
+                    analysis_next_retry_at TEXT
                 )
                 """
             )
@@ -182,10 +186,29 @@ class Database:
             columns = {
                 row[1] for row in connection.execute("PRAGMA table_info(vacancies)")
             }
-            for name in ("applying_at", "submit_attempted_at"):
+            migrations = {
+                "applying_at": "TEXT",
+                "submit_attempted_at": "TEXT",
+                "analysis_retry_count": "INTEGER NOT NULL DEFAULT 0",
+                "analysis_next_retry_at": "TEXT",
+            }
+            for name, definition in migrations.items():
                 if name not in columns:
-                    connection.execute(f"ALTER TABLE vacancies ADD COLUMN {name} TEXT")
+                    connection.execute(
+                        f"ALTER TABLE vacancies ADD COLUMN {name} {definition}"
+                    )
             self._migrate_status_check(connection)
+            connection.execute(
+                """
+                UPDATE vacancies
+                SET analysis_retry_count = 1,
+                    analysis_next_retry_at = discovered_at
+                WHERE status = ?
+                  AND analysis_retry_count = 0
+                  AND analysis_next_retry_at IS NULL
+                """,
+                (VacancyStatus.ANALYSIS_FAILED.value,),
+            )
 
     def _migrate_status_check(self, connection: sqlite3.Connection) -> None:
         """Пересоздать таблицу vacancies если CHECK-ограничение не включает новые статусы.
@@ -231,11 +254,42 @@ class Database:
                 applied_at TEXT,
                 approver_id INTEGER,
                 permit_hash TEXT,
-                error_text TEXT NOT NULL DEFAULT ''
+                error_text TEXT NOT NULL DEFAULT '',
+                analysis_retry_count INTEGER NOT NULL DEFAULT 0,
+                analysis_next_retry_at TEXT
             )
             """
         )
-        connection.execute("INSERT INTO vacancies SELECT * FROM _vacancies_old")
+        columns = (
+            "id",
+            "title",
+            "company",
+            "url",
+            "description_hash",
+            "search_query",
+            "llm_decision",
+            "llm_reason",
+            "confidence",
+            "cover_letter",
+            "status",
+            "discovered_at",
+            "approval_requested_at",
+            "approval_expires_at",
+            "approved_at",
+            "applying_at",
+            "submit_attempted_at",
+            "applied_at",
+            "approver_id",
+            "permit_hash",
+            "error_text",
+            "analysis_retry_count",
+            "analysis_next_retry_at",
+        )
+        column_list = ", ".join(columns)
+        connection.execute(
+            f"INSERT INTO vacancies ({column_list}) "
+            f"SELECT {column_list} FROM _vacancies_old"
+        )
         connection.execute("DROP TABLE _vacancies_old")
         connection.execute(
             "CREATE INDEX IF NOT EXISTS vacancies_status_idx ON vacancies(status)"
@@ -279,6 +333,8 @@ class Database:
             applied_at=row["applied_at"],
             approver_id=row["approver_id"],
             error_text=row["error_text"],
+            analysis_retry_count=row["analysis_retry_count"],
+            analysis_next_retry_at=row["analysis_next_retry_at"],
         )
 
     def discover(
@@ -318,6 +374,77 @@ class Database:
             return self._vacancy(
                 connection.execute("SELECT * FROM vacancies WHERE id = ?", (job_id,)).fetchone()
             )
+
+    def unprocessed_discovered(self) -> list[Vacancy]:
+        with self._connect() as connection:
+            rows = connection.execute(
+                """
+                SELECT * FROM vacancies
+                WHERE status = ? AND llm_decision IS NULL
+                ORDER BY discovered_at
+                """,
+                (VacancyStatus.DISCOVERED.value,),
+            ).fetchall()
+            return [self._vacancy(row) for row in rows]
+
+    def mark_analysis_failed(
+        self,
+        job_id: str,
+        *,
+        error_type: str,
+        now: datetime,
+        retry_after: timedelta,
+        max_attempts: int,
+    ) -> bool:
+        if max_attempts < 1:
+            raise ValueError("max_attempts must be positive")
+        with self._connect() as connection:
+            cursor = connection.execute(
+                """
+                UPDATE vacancies SET
+                    status = ?, llm_decision = NULL, error_text = ?,
+                    analysis_retry_count = analysis_retry_count + 1,
+                    analysis_next_retry_at = CASE
+                        WHEN analysis_retry_count + 1 < ? THEN ?
+                        ELSE NULL
+                    END
+                WHERE id = ? AND status = ? AND analysis_retry_count < ?
+                """,
+                (
+                    VacancyStatus.ANALYSIS_FAILED.value,
+                    error_type,
+                    max_attempts,
+                    _iso(now + retry_after),
+                    job_id,
+                    VacancyStatus.DISCOVERED.value,
+                    max_attempts,
+                ),
+            )
+            return cursor.rowcount == 1
+
+    def requeue_due_analysis_failures(
+        self, now: datetime, *, max_attempts: int
+    ) -> int:
+        if max_attempts < 1:
+            raise ValueError("max_attempts must be positive")
+        with self._connect() as connection:
+            cursor = connection.execute(
+                """
+                UPDATE vacancies
+                SET status = ?, analysis_next_retry_at = NULL
+                WHERE status = ?
+                  AND analysis_retry_count < ?
+                  AND analysis_next_retry_at IS NOT NULL
+                  AND analysis_next_retry_at <= ?
+                """,
+                (
+                    VacancyStatus.DISCOVERED.value,
+                    VacancyStatus.ANALYSIS_FAILED.value,
+                    max_attempts,
+                    _iso(now),
+                ),
+            )
+            return cursor.rowcount
 
     def transition(
         self,
@@ -393,7 +520,8 @@ class Database:
             cursor = connection.execute(
                 """
                 UPDATE vacancies SET cover_letter = ?, llm_decision = ?,
-                    llm_reason = ?, confidence = ?
+                    llm_reason = ?, confidence = ?, error_text = '',
+                    analysis_next_retry_at = NULL
                 WHERE id = ? AND status = ?
                 """,
                 (

--- a/main.py
+++ b/main.py
@@ -6,7 +6,7 @@ import hashlib
 import logging
 import sys
 from collections.abc import Callable
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 from ai_analyzer import AnalysisError, VacancyAnalyzer
@@ -25,6 +25,7 @@ from vacancy_filter import title_rejection_reason
 
 
 logger = logging.getLogger(__name__)
+ANALYSIS_MAX_ATTEMPTS = 3
 
 
 async def process_vacancy(
@@ -37,8 +38,13 @@ async def process_vacancy(
     *,
     now_factory: Callable[[], datetime] | None = None,
 ) -> None:
-    now = (now_factory or (lambda: datetime.now(UTC)))()
-    if database.get(summary.id) is not None:
+    clock = now_factory or (lambda: datetime.now(UTC))
+    now = clock()
+    existing = database.get(summary.id)
+    if existing is not None and (
+        existing.status is not VacancyStatus.DISCOVERED
+        or existing.llm_decision is not None
+    ):
         return
     details = await hh_client.read_vacancy(summary, telegram.request_captcha)
     description_hash = (
@@ -46,17 +52,20 @@ async def process_vacancy(
         if details.description
         else ""
     )
-    if not database.discover(
-        job_id=summary.id,
-        title=summary.title,
-        company=details.company,
-        url=summary.url,
-        description_hash=description_hash,
-        search_query=summary.search_query,
-        discovered_at=now,
-    ):
-        return
-    logger.info("vacancy_discovered job_id=%s", summary.id)
+    if existing is None:
+        if not database.discover(
+            job_id=summary.id,
+            title=summary.title,
+            company=details.company,
+            url=summary.url,
+            description_hash=description_hash,
+            search_query=summary.search_query,
+            discovered_at=now,
+        ):
+            return
+        logger.info("vacancy_discovered job_id=%s", summary.id)
+    else:
+        logger.info("vacancy_resumed job_id=%s", summary.id)
     if details.state is not PageState.VACANCY_LOADED:
         error = details.error or details.state.value
         database.transition(
@@ -86,11 +95,12 @@ async def process_vacancy(
     try:
         suitability = await analyzer.assess(summary.title, details.description)
     except AnalysisError as exc:
-        database.transition(
+        database.mark_analysis_failed(
             summary.id,
-            VacancyStatus.DISCOVERED,
-            VacancyStatus.ANALYSIS_FAILED,
-            error_text=exc.error_type,
+            error_type=exc.error_type,
+            now=clock(),
+            retry_after=timedelta(minutes=settings.check_interval_minutes),
+            max_attempts=ANALYSIS_MAX_ATTEMPTS,
         )
         await telegram.notify_analysis_failed(summary.title, summary.url, exc.error_type)
         logger.warning("vacancy_analysis_failed job_id=%s error_type=%s", summary.id, exc.error_type)
@@ -104,6 +114,7 @@ async def process_vacancy(
             llm_decision=False,
             llm_reason=suitability.reason,
             confidence=suitability.confidence,
+            error_text="",
         )
         logger.info("vacancy_rejected job_id=%s source=llm", summary.id)
         return
@@ -142,6 +153,39 @@ async def process_vacancy(
         await telegram.send_preview(database.get(summary.id), include_actions=True)
 
 
+async def retry_due_analyses(
+    settings: Settings,
+    database: Database,
+    hh_client: HHClient,
+    analyzer: VacancyAnalyzer,
+    telegram: TelegramService,
+    *,
+    now_factory: Callable[[], datetime] | None = None,
+) -> None:
+    clock = now_factory or (lambda: datetime.now(UTC))
+    now = clock()
+    # ponytail: one worker owns this lifecycle; add per-row claims if
+    # multi-worker deployments matter.
+    database.requeue_due_analysis_failures(
+        now, max_attempts=ANALYSIS_MAX_ATTEMPTS
+    )
+    for vacancy in database.unprocessed_discovered():
+        await process_vacancy(
+            VacancySummary(
+                vacancy.id,
+                vacancy.title,
+                vacancy.url,
+                vacancy.search_query,
+            ),
+            settings,
+            database,
+            hh_client,
+            analyzer,
+            telegram,
+            now_factory=clock,
+        )
+
+
 async def agent_loop(
     settings: Settings,
     database: Database,
@@ -152,7 +196,15 @@ async def agent_loop(
 ) -> None:
     while True:
         if not control.paused:
-            database.expire_pending(datetime.now(UTC))
+            now = datetime.now(UTC)
+            database.expire_pending(now)
+            await retry_due_analyses(
+                settings,
+                database,
+                hh_client,
+                analyzer,
+                telegram,
+            )
             for query in settings.profile.hh.search_queries:
                 if control.paused:
                     break

--- a/main.py
+++ b/main.py
@@ -159,6 +159,7 @@ async def retry_due_analyses(
     hh_client: HHClient,
     analyzer: VacancyAnalyzer,
     telegram: TelegramService,
+    control: AgentControl,
     *,
     now_factory: Callable[[], datetime] | None = None,
 ) -> None:
@@ -170,6 +171,8 @@ async def retry_due_analyses(
         now, max_attempts=ANALYSIS_MAX_ATTEMPTS
     )
     for vacancy in database.unprocessed_discovered():
+        if control.paused:
+            break
         await process_vacancy(
             VacancySummary(
                 vacancy.id,
@@ -204,6 +207,7 @@ async def agent_loop(
                 hh_client,
                 analyzer,
                 telegram,
+                control,
             )
             for query in settings.profile.hh.search_queries:
                 if control.paused:

--- a/tests/test_ai_analyzer.py
+++ b/tests/test_ai_analyzer.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 
-from ai_analyzer import SuitabilityResult, VacancyAnalyzer
+from ai_analyzer import AnalysisError, SuitabilityResult, VacancyAnalyzer
 from config import load_settings
 from database import Database
 from llm.managed import ManagedLLMProvider
@@ -83,11 +83,10 @@ def test_valid_structured_suitability_is_accepted(tmp_path: Path) -> None:
 def test_invalid_structured_results_fail_closed(tmp_path: Path, raw: str) -> None:
     vacancy_analyzer, _ = analyzer(tmp_path, [response(raw)])
 
-    result = asyncio.run(vacancy_analyzer.assess("Developer", "Description"))
+    with pytest.raises(AnalysisError) as captured:
+        asyncio.run(vacancy_analyzer.assess("Developer", "Description"))
 
-    assert result == SuitabilityResult(
-        suitable=False, confidence=0.0, reason="Invalid model response"
-    )
+    assert captured.value.error_type == "invalid_response"
 
 
 def test_schema_failure_gets_at_most_one_managed_retry(tmp_path: Path) -> None:

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -94,6 +94,169 @@ def test_duplicate_discovery_is_rejected(tmp_path: Path) -> None:
     assert database.get("job-1").title == "Python developer"
 
 
+def test_analysis_failure_retry_is_due_once_per_cycle_and_stops_after_three(
+    tmp_path: Path,
+) -> None:
+    database = make_database(tmp_path)
+    discover(database, letter="")
+    retry_delay = timedelta(minutes=30)
+
+    assert database.mark_analysis_failed(
+        "job-1",
+        error_type="timeout",
+        now=NOW,
+        retry_after=retry_delay,
+        max_attempts=3,
+    )
+    first_failure = database.get("job-1")
+    assert first_failure.status is VacancyStatus.ANALYSIS_FAILED
+    assert first_failure.llm_decision is None
+    assert first_failure.error_text == "timeout"
+    assert first_failure.analysis_retry_count == 1
+    assert first_failure.analysis_next_retry_at == (
+        NOW + timedelta(minutes=30)
+    ).isoformat()
+    assert database.requeue_due_analysis_failures(
+        NOW + timedelta(minutes=29), max_attempts=3
+    ) == 0
+
+    assert database.requeue_due_analysis_failures(
+        NOW + timedelta(minutes=30), max_attempts=3
+    ) == 1
+    assert database.get("job-1").status is VacancyStatus.DISCOVERED
+
+    assert database.mark_analysis_failed(
+        "job-1",
+        error_type="transient_server",
+        now=NOW + timedelta(minutes=30),
+        retry_after=retry_delay,
+        max_attempts=3,
+    )
+    assert database.get("job-1").analysis_retry_count == 2
+    assert database.requeue_due_analysis_failures(
+        NOW + timedelta(minutes=60), max_attempts=3
+    ) == 1
+
+    assert database.mark_analysis_failed(
+        "job-1",
+        error_type="timeout",
+        now=NOW + timedelta(minutes=60),
+        retry_after=retry_delay,
+        max_attempts=3,
+    )
+    exhausted = database.get("job-1")
+    assert exhausted.status is VacancyStatus.ANALYSIS_FAILED
+    assert exhausted.analysis_retry_count == 3
+    assert exhausted.analysis_next_retry_at is None
+    assert database.requeue_due_analysis_failures(
+        NOW + timedelta(days=1), max_attempts=3
+    ) == 0
+
+
+def test_status_migration_preserves_vacancy_and_adds_retry_state(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "legacy.db"
+    statuses = ", ".join(
+        f"'{status.value}'"
+        for status in VacancyStatus
+        if status is not VacancyStatus.ANALYSIS_FAILED
+    )
+    with sqlite3.connect(path) as connection:
+        connection.execute(
+            f"""
+            CREATE TABLE vacancies (
+                id TEXT PRIMARY KEY,
+                title TEXT NOT NULL,
+                company TEXT NOT NULL DEFAULT '',
+                url TEXT NOT NULL,
+                description_hash TEXT NOT NULL DEFAULT '',
+                search_query TEXT NOT NULL DEFAULT '',
+                llm_decision INTEGER,
+                llm_reason TEXT NOT NULL DEFAULT '',
+                confidence REAL,
+                cover_letter TEXT NOT NULL DEFAULT '',
+                status TEXT NOT NULL CHECK (status IN ({statuses})),
+                discovered_at TEXT NOT NULL,
+                approval_requested_at TEXT,
+                approval_expires_at TEXT,
+                approved_at TEXT,
+                applied_at TEXT,
+                approver_id INTEGER,
+                permit_hash TEXT,
+                error_text TEXT NOT NULL DEFAULT '',
+                applying_at TEXT,
+                submit_attempted_at TEXT
+            )
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO vacancies (
+                id, title, company, url, description_hash, search_query,
+                status, discovered_at, approval_requested_at,
+                approval_expires_at, approved_at, applied_at, approver_id,
+                permit_hash, error_text, applying_at, submit_attempted_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "legacy-job",
+                "Legacy developer",
+                "Legacy Co",
+                "https://example.com/legacy",
+                "legacy-hash",
+                "Python",
+                VacancyStatus.DISCOVERED.value,
+                "2026-07-20T09:00:00+00:00",
+                "requested",
+                "expires",
+                "approved",
+                "applied",
+                42,
+                "permit",
+                "legacy error",
+                "applying",
+                "submitted",
+            ),
+        )
+
+    database = Database(path)
+    database.init()
+
+    vacancy = database.get("legacy-job")
+    assert vacancy.title == "Legacy developer"
+    assert vacancy.approval_requested_at == "requested"
+    assert vacancy.approval_expires_at == "expires"
+    assert vacancy.approved_at == "approved"
+    assert vacancy.applying_at == "applying"
+    assert vacancy.submit_attempted_at == "submitted"
+    assert vacancy.applied_at == "applied"
+    assert vacancy.approver_id == 42
+    assert vacancy.error_text == "legacy error"
+    assert vacancy.analysis_retry_count == 0
+    assert vacancy.analysis_next_retry_at is None
+
+
+def test_existing_analysis_failure_becomes_due_after_retry_migration(
+    tmp_path: Path,
+) -> None:
+    database = make_database(tmp_path)
+    discover(database, letter="")
+    assert database.transition(
+        "job-1",
+        VacancyStatus.DISCOVERED,
+        VacancyStatus.ANALYSIS_FAILED,
+        error_text="timeout",
+    )
+
+    database.init()
+
+    vacancy = database.get("job-1")
+    assert vacancy.analysis_retry_count == 1
+    assert vacancy.analysis_next_retry_at == vacancy.discovered_at
+    assert database.requeue_due_analysis_failures(NOW, max_attempts=3) == 1
+
+
 def test_expired_pending_approval_cannot_be_approved(tmp_path: Path) -> None:
     database = make_database(tmp_path)
     discover(database)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2,17 +2,21 @@ import asyncio
 import subprocess
 import sys
 from dataclasses import replace
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
-from ai_analyzer import SuitabilityResult, VacancyAnalyzer
+import pytest
+
+import main as main_module
+from ai_analyzer import AnalysisError, SuitabilityResult, VacancyAnalyzer
 from config import load_settings
 from database import Database, VacancyStatus
 from hh_client import PageState, VacancyDetails, VacancySummary
 from llm.errors import LLMAuthenticationError
 from llm.managed import ManagedLLMProvider
 from llm.providers.fake import FakeProvider
-from main import process_vacancy
+from main import agent_loop, process_vacancy
+from tg_bot import AgentControl
 from tests.test_config import VALID_ENV, write_profile
 
 
@@ -30,6 +34,15 @@ class FakeHHClient:
         return self.details
 
 
+class SearchReached(Exception):
+    pass
+
+
+class StopAtSearchHHClient(FakeHHClient):
+    async def search_vacancies(self, *_args):
+        raise SearchReached
+
+
 class FakeAnalyzer:
     async def assess(self, title: str, description: str) -> SuitabilityResult:
         return SuitabilityResult(
@@ -38,6 +51,17 @@ class FakeAnalyzer:
 
     async def generate_cover_letter(self, title: str, description: str) -> str:
         return "Safe local-profile letter"
+
+
+class SequenceAnalyzer(FakeAnalyzer):
+    def __init__(self, outcomes: list[SuitabilityResult | Exception]):
+        self.outcomes = iter(outcomes)
+
+    async def assess(self, title: str, description: str) -> SuitabilityResult:
+        outcome = next(self.outcomes)
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
 
 
 class FakeTelegram:
@@ -50,6 +74,9 @@ class FakeTelegram:
 
     async def notify(self, text: str):
         self.notifications.append(text)
+
+    async def notify_analysis_failed(self, title: str, url: str, error_type: str):
+        self.notifications.append(error_type)
 
     async def request_captcha(self, screenshot, title: str, timeout_seconds: int):
         return None
@@ -141,7 +168,7 @@ def test_browser_read_error_is_persisted_as_apply_failed(tmp_path: Path) -> None
     assert "navigation failed" in vacancy.error_text
 
 
-def test_llm_failure_rejects_vacancy_without_requesting_approval(
+def test_llm_failure_is_saved_without_rejection_or_approval(
     tmp_path: Path,
 ) -> None:
     app_settings = settings(tmp_path, "approval")
@@ -171,8 +198,244 @@ def test_llm_failure_rejects_vacancy_without_requesting_approval(
     )
 
     vacancy = database.get("job-1")
-    assert vacancy.status is VacancyStatus.REJECTED_BY_LLM
+    assert vacancy.status is VacancyStatus.ANALYSIS_FAILED
+    assert vacancy.llm_decision is None
+    assert vacancy.error_text == "authentication"
+    assert vacancy.analysis_retry_count == 1
+    assert vacancy.analysis_next_retry_at == (
+        NOW + timedelta(minutes=app_settings.check_interval_minutes)
+    ).isoformat()
     assert vacancy.cover_letter == ""
+    assert telegram.previews == []
+    assert telegram.notifications == ["authentication"]
+
+
+def test_analysis_retry_delay_starts_when_failed_analysis_finishes(
+    tmp_path: Path,
+) -> None:
+    app_settings = settings(tmp_path, "approval")
+    database = Database(app_settings.database_path)
+    database.init()
+    telegram = FakeTelegram()
+    details = VacancyDetails(
+        SUMMARY, PageState.VACANCY_LOADED, "Example", "Build Python services"
+    )
+    times = iter((NOW, NOW + timedelta(minutes=5)))
+
+    asyncio.run(
+        process_vacancy(
+            SUMMARY,
+            app_settings,
+            database,
+            FakeHHClient(details),
+            SequenceAnalyzer([AnalysisError("timeout")]),
+            telegram,
+            now_factory=lambda: next(times),
+        )
+    )
+
+    assert database.get(SUMMARY.id).analysis_next_retry_at == (
+        NOW
+        + timedelta(minutes=5)
+        + timedelta(minutes=app_settings.check_interval_minutes)
+    ).isoformat()
+
+
+def test_failed_retry_delay_starts_when_retry_finishes(tmp_path: Path) -> None:
+    app_settings = settings(tmp_path, "approval")
+    database = Database(app_settings.database_path)
+    database.init()
+    assert database.discover(
+        job_id=SUMMARY.id,
+        title=SUMMARY.title,
+        company="Example",
+        url=SUMMARY.url,
+        description_hash="abc123",
+        search_query=SUMMARY.search_query,
+        discovered_at=NOW,
+    )
+    assert database.mark_analysis_failed(
+        SUMMARY.id,
+        error_type="timeout",
+        now=NOW,
+        retry_after=timedelta(minutes=30),
+        max_attempts=3,
+    )
+    telegram = FakeTelegram()
+    details = VacancyDetails(
+        SUMMARY, PageState.VACANCY_LOADED, "Example", "Build Python services"
+    )
+    times = iter(
+        (
+            NOW + timedelta(minutes=30),
+            NOW + timedelta(minutes=30),
+            NOW + timedelta(minutes=35),
+        )
+    )
+
+    asyncio.run(
+        main_module.retry_due_analyses(
+            app_settings,
+            database,
+            FakeHHClient(details),
+            SequenceAnalyzer([AnalysisError("timeout")]),
+            telegram,
+            now_factory=lambda: next(times),
+        )
+    )
+
+    vacancy = database.get(SUMMARY.id)
+    assert vacancy.analysis_retry_count == 2
+    assert vacancy.analysis_next_retry_at == (
+        NOW
+        + timedelta(minutes=35)
+        + timedelta(minutes=app_settings.check_interval_minutes)
+    ).isoformat()
+
+
+def test_agent_loop_retries_due_analysis_before_new_search(tmp_path: Path) -> None:
+    app_settings = settings(tmp_path, "approval")
+    database = Database(app_settings.database_path)
+    database.init()
+    assert database.discover(
+        job_id=SUMMARY.id,
+        title=SUMMARY.title,
+        company="Example",
+        url=SUMMARY.url,
+        description_hash="abc123",
+        search_query=SUMMARY.search_query,
+        discovered_at=NOW,
+    )
+    assert database.mark_analysis_failed(
+        SUMMARY.id,
+        error_type="timeout",
+        now=NOW,
+        retry_after=timedelta(minutes=30),
+        max_attempts=3,
+    )
+    telegram = FakeTelegram()
+    details = VacancyDetails(
+        SUMMARY, PageState.VACANCY_LOADED, "Example", "Build Python services"
+    )
+
+    with pytest.raises(SearchReached):
+        asyncio.run(
+            agent_loop(
+                app_settings,
+                database,
+                StopAtSearchHHClient(details),
+                SequenceAnalyzer(
+                    [
+                        SuitabilityResult(
+                            suitable=True,
+                            confidence=0.91,
+                            reason="Relevant work",
+                        )
+                    ]
+                ),
+                telegram,
+                AgentControl(),
+            )
+        )
+
+    vacancy = database.get(SUMMARY.id)
+    assert vacancy.status is VacancyStatus.PENDING_APPROVAL
+    assert vacancy.error_text == ""
+    assert telegram.previews == [(SUMMARY.id, True)]
+
+
+def test_agent_loop_resumes_interrupted_discovered_analysis_before_search(
+    tmp_path: Path,
+) -> None:
+    app_settings = settings(tmp_path, "approval")
+    database = Database(app_settings.database_path)
+    database.init()
+    assert database.discover(
+        job_id=SUMMARY.id,
+        title=SUMMARY.title,
+        company="Example",
+        url=SUMMARY.url,
+        description_hash="abc123",
+        search_query=SUMMARY.search_query,
+        discovered_at=NOW,
+    )
+    telegram = FakeTelegram()
+    details = VacancyDetails(
+        SUMMARY, PageState.VACANCY_LOADED, "Example", "Build Python services"
+    )
+
+    with pytest.raises(SearchReached):
+        asyncio.run(
+            agent_loop(
+                app_settings,
+                database,
+                StopAtSearchHHClient(details),
+                SequenceAnalyzer(
+                    [
+                        SuitabilityResult(
+                            suitable=True,
+                            confidence=0.91,
+                            reason="Relevant work",
+                        )
+                    ]
+                ),
+                telegram,
+                AgentControl(),
+            )
+        )
+
+    assert database.get(SUMMARY.id).status is VacancyStatus.PENDING_APPROVAL
+    assert telegram.previews == [(SUMMARY.id, True)]
+
+
+def test_retry_uses_valid_negative_decision_instead_of_technical_error(
+    tmp_path: Path,
+) -> None:
+    app_settings = settings(tmp_path, "approval")
+    database = Database(app_settings.database_path)
+    database.init()
+    telegram = FakeTelegram()
+    details = VacancyDetails(
+        SUMMARY, PageState.VACANCY_LOADED, "Example", "Build Python services"
+    )
+    analyzer = SequenceAnalyzer(
+        [
+            AnalysisError("timeout"),
+            SuitabilityResult(
+                suitable=False,
+                confidence=0.2,
+                reason="Role mismatch",
+            ),
+        ]
+    )
+
+    asyncio.run(
+        process_vacancy(
+            SUMMARY,
+            app_settings,
+            database,
+            FakeHHClient(details),
+            analyzer,
+            telegram,
+            now_factory=lambda: NOW,
+        )
+    )
+    asyncio.run(
+        main_module.retry_due_analyses(
+            app_settings,
+            database,
+            FakeHHClient(details),
+            analyzer,
+            telegram,
+            now_factory=lambda: NOW + timedelta(minutes=30),
+        )
+    )
+
+    vacancy = database.get(SUMMARY.id)
+    assert vacancy.status is VacancyStatus.REJECTED_BY_LLM
+    assert vacancy.llm_decision is False
+    assert vacancy.llm_reason == "Role mismatch"
+    assert vacancy.error_text == ""
     assert telegram.previews == []
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -12,9 +12,10 @@ from ai_analyzer import AnalysisError, SuitabilityResult, VacancyAnalyzer
 from config import load_settings
 from database import Database, VacancyStatus
 from hh_client import PageState, VacancyDetails, VacancySummary
-from llm.errors import LLMAuthenticationError
+from llm.errors import LLMAuthenticationError, LLMTimeoutError
 from llm.managed import ManagedLLMProvider
 from llm.providers.fake import FakeProvider
+from llm.types import LLMResponse
 from main import agent_loop, process_vacancy
 from tg_bot import AgentControl
 from tests.test_config import VALID_ENV, write_profile
@@ -62,6 +63,17 @@ class SequenceAnalyzer(FakeAnalyzer):
         if isinstance(outcome, Exception):
             raise outcome
         return outcome
+
+
+class PausingAnalyzer(FakeAnalyzer):
+    def __init__(self, control: AgentControl):
+        self.control = control
+        self.calls = 0
+
+    async def assess(self, title: str, description: str) -> SuitabilityResult:
+        self.calls += 1
+        self.control.paused = True
+        return await super().assess(title, description)
 
 
 class FakeTelegram:
@@ -280,6 +292,7 @@ def test_failed_retry_delay_starts_when_retry_finishes(tmp_path: Path) -> None:
             FakeHHClient(details),
             SequenceAnalyzer([AnalysisError("timeout")]),
             telegram,
+            AgentControl(),
             now_factory=lambda: next(times),
         )
     )
@@ -291,6 +304,122 @@ def test_failed_retry_delay_starts_when_retry_finishes(tmp_path: Path) -> None:
         + timedelta(minutes=35)
         + timedelta(minutes=app_settings.check_interval_minutes)
     ).isoformat()
+
+
+def test_pause_stops_retry_backlog_before_next_vacancy(tmp_path: Path) -> None:
+    app_settings = settings(tmp_path, "approval")
+    database = Database(app_settings.database_path)
+    database.init()
+    second = VacancySummary(
+        "job-2", "Backend developer", "https://example.com/vacancy/job-2", "Python"
+    )
+    for offset, summary in enumerate((SUMMARY, second)):
+        discovered_at = NOW + timedelta(seconds=offset)
+        assert database.discover(
+            job_id=summary.id,
+            title=summary.title,
+            company="Example",
+            url=summary.url,
+            description_hash=f"hash-{offset}",
+            search_query=summary.search_query,
+            discovered_at=discovered_at,
+        )
+        assert database.mark_analysis_failed(
+            summary.id,
+            error_type="timeout",
+            now=discovered_at,
+            retry_after=timedelta(minutes=30),
+            max_attempts=3,
+        )
+    control = AgentControl()
+    analyzer = PausingAnalyzer(control)
+    details = VacancyDetails(
+        SUMMARY, PageState.VACANCY_LOADED, "Example", "Build Python services"
+    )
+
+    asyncio.run(
+        main_module.retry_due_analyses(
+            app_settings,
+            database,
+            FakeHHClient(details),
+            analyzer,
+            FakeTelegram(),
+            control,
+            now_factory=lambda: NOW + timedelta(minutes=31),
+        )
+    )
+
+    assert analyzer.calls == 1
+    assert database.get(SUMMARY.id).status is VacancyStatus.PENDING_APPROVAL
+    assert database.get(second.id).status is VacancyStatus.DISCOVERED
+
+
+def test_three_timeouts_are_retried_in_later_cycle(tmp_path: Path) -> None:
+    app_settings = settings(tmp_path, "approval")
+    database = Database(app_settings.database_path)
+    database.init()
+    adapter = FakeProvider(
+        [
+            LLMTimeoutError(),
+            LLMTimeoutError(),
+            LLMTimeoutError(),
+            LLMResponse(
+                text='{"suitable":true,"confidence":0.91,"reason":"Relevant work"}',
+                provider="fake",
+                model="test-model",
+            ),
+            LLMResponse(
+                text="Safe local-profile letter", provider="fake", model="test-model"
+            ),
+        ]
+    )
+
+    async def no_sleep(_seconds: float) -> None:
+        pass
+
+    provider = ManagedLLMProvider(
+        adapter,
+        database,
+        max_retries=2,
+        max_requests_per_day=100,
+        sleep=no_sleep,
+        now_factory=lambda: NOW,
+    )
+    analyzer = VacancyAnalyzer(app_settings, provider)
+    telegram = FakeTelegram()
+    details = VacancyDetails(
+        SUMMARY, PageState.VACANCY_LOADED, "Example", "Build Python services"
+    )
+
+    asyncio.run(
+        process_vacancy(
+            SUMMARY,
+            app_settings,
+            database,
+            FakeHHClient(details),
+            analyzer,
+            telegram,
+            now_factory=lambda: NOW,
+        )
+    )
+    assert database.get(SUMMARY.id).status is VacancyStatus.ANALYSIS_FAILED
+
+    asyncio.run(
+        main_module.retry_due_analyses(
+            app_settings,
+            database,
+            FakeHHClient(details),
+            analyzer,
+            telegram,
+            AgentControl(),
+            now_factory=lambda: NOW + timedelta(minutes=30),
+        )
+    )
+
+    vacancy = database.get(SUMMARY.id)
+    assert vacancy.status is VacancyStatus.PENDING_APPROVAL
+    assert vacancy.llm_decision is True
+    assert len(adapter.requests) == 5
 
 
 def test_agent_loop_retries_due_analysis_before_new_search(tmp_path: Path) -> None:
@@ -427,6 +556,7 @@ def test_retry_uses_valid_negative_decision_instead_of_technical_error(
             FakeHHClient(details),
             analyzer,
             telegram,
+            AgentControl(),
             now_factory=lambda: NOW + timedelta(minutes=30),
         )
     )


### PR DESCRIPTION
## Что изменено

- технические ошибки LLM сохраняются как `ANALYSIS_FAILED` и больше не считаются решением о непригодности вакансии;
- после исходного анализа выполняется не более двух повторных полных анализов с задержкой не меньше `CHECK_INTERVAL_MINUTES`;
- due-вакансии и прерванные `DISCOVERED` обрабатываются перед новым поиском;
- `/pause` останавливает retry-очередь перед следующей вакансией;
- существующие строки `ANALYSIS_FAILED` получают совместимый retry state при миграции;
- SQLite-миграция копирует колонки явно и сохраняет значения старых строк независимо от порядка колонок.

## Причина

Статус `ANALYSIS_FAILED` отделил технический сбой от `REJECTED_BY_LLM`, но стал терминальным: повторное обнаружение использовало `INSERT OR IGNORE`, а следующий цикл не выбирал failed-записи. В итоге вакансия после исчерпания внутренних provider retries больше никогда не анализировалась.

## Поведение

- максимум три полных анализа вакансии: исходный и два повторных;
- backoff начинается после фактического завершения неудачного анализа, включая повторный;
- только валидный отрицательный ответ LLM переводит вакансию в `REJECTED_BY_LLM`;
- provider retries, конфигурация, зависимости и application flow не меняются.

## Проверки

- `python -m pytest -q` — 178 passed;
- `python -m compileall -q .`;
- `git diff --check`;
- независимый review после последних исправлений: Critical/Important замечаний нет.
